### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -22,7 +22,7 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
 
     var $supportedModes = array('xhtml', 'metadata');
 
-    public function register(Doku_Event_Handler &$controller) 
+    public function register(Doku_Event_Handler $controller) 
     {
         $controller->register_hook('ACTION_SHOW_REDIRECT', 'BEFORE', $this, '_updateSavedStats');
         $controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, '_cachePrepare');

--- a/syntax.php
+++ b/syntax.php
@@ -42,12 +42,12 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
         $this->Lexer->addSpecialPattern('<AUTHORSTATS YEARGRAPH>',$mode,'plugin_authorstats');
     }
 
-    public function handle($match, $state, $pos, &$handler)
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         return array($match);
     }
 
-    public function render($mode, &$renderer, $data) 
+    public function render($mode, Doku_Renderer $renderer, $data) 
     {
 
         if ($mode == "metadata") 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.