### PR TITLE
Merge of pull #24 & #30 (which should solve issue #28)

### DIFF
--- a/action.php
+++ b/action.php
@@ -17,12 +17,12 @@ if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 require_once DOKU_PLUGIN.'action.php';
 require_once DOKU_PLUGIN.'authorstats/helpers.php';
 
-class action_plugin_authorstats extends DokuWiki_Action_Plugin 
+class action_plugin_authorstats extends DokuWiki_Action_Plugin
 {
 
     var $supportedModes = array('xhtml', 'metadata');
 
-    public function register(Doku_Event_Handler &$controller) 
+    public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('ACTION_SHOW_REDIRECT', 'BEFORE', $this, '_updateSavedStats');
         $controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, '_cachePrepare');
@@ -31,8 +31,8 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
 
     // Updates the saved statistics by checking the last lines
     // in the /data/meta/ directory
-    public function _updateSavedStats() 
-    {   
+    public function _updateSavedStats()
+    {
         global $conf;
         $dir = $conf['metadir'] . '/';
 
@@ -42,10 +42,10 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
         // Read saved data from JSON file
         $sd = authorstatsReadJSON();
 
-        // Get last change 
+        // Get last change
         $lastchange = empty($sd) ?  (-1*PHP_INT_MAX )-1 : (int) $sd["lastchange"];
-        $newlast = $lastchange; 
-        foreach ($files as $file) 
+        $newlast = $lastchange;
+        foreach ($files as $file)
         {
             $file_contents = array_reverse(file($file));
             foreach($file_contents as $line)
@@ -60,23 +60,23 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
                 // If the author is not in the array, initialize his stats
                 if (!isset($sd["authors"][$r["author"]]))
                 {
-                    $sd["authors"][$r["author"]]["C"] = 0; 
+                    $sd["authors"][$r["author"]]["C"] = 0;
                     $sd["authors"][$r["author"]]["E"] = 0;
                     $sd["authors"][$r["author"]]["e"] = 0;
                     $sd["authors"][$r["author"]]["D"] = 0;
                     $sd["authors"][$r["author"]]["R"] = 0;
-                    $sd["authors"][$r["author"]]["pm"] = Array(); 
-                } 
+                    $sd["authors"][$r["author"]]["pm"] = Array();
+                }
                 else
                 {
                     // Initialize month if doesn't exist
                     // else increment it
-                    if (!isset($sd["authors"][$r["author"]]["pm"][$r["date"]])) 
+                    if (!isset($sd["authors"][$r["author"]]["pm"][$r["date"]]))
                         $sd["authors"][$r["author"]]["pm"][$r["date"]] = 1;
-                    else 
+                    else
                         $sd["authors"][$r["author"]]["pm"][$r["date"]]++;
                 }
-                $sd["authors"][$r["author"]][$r["type"]]++; 
+                $sd["authors"][$r["author"]][$r["type"]]++;
             }
         }
         $sd["lastchange"] = $newlast;
@@ -84,8 +84,8 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
     }
 
     // If the page is no more recent than the modification of the json file, refresh the page.
-    public function _cachePrepare(&$event, $param) 
-    {   
+    public function _cachePrepare($event, $param)
+    {
         $cache =& $event->data;
 
         if(!isset($cache->page)) return;
@@ -93,9 +93,9 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
 
         $enabled = p_get_metadata($cache->page, 'authorstats-enabled');
 
-        if (isset($enabled)) 
+        if (isset($enabled))
         {
-            if (@filemtime($cache->cache) < @filemtime(DOKU_PLUGIN."authorstats/authorstats.json")) 
+            if (@filemtime($cache->cache) < @filemtime(DOKU_PLUGIN."authorstats/authorstats.json"))
             {
                 $event->preventDefault();
                 $event->stopPropagation();
@@ -104,28 +104,28 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
         }
     }
 
-    function _getChangeLogs($dir, &$files = array()) 
-    {    
-        if ($dh = opendir($dir)) 
+    function _getChangeLogs($dir, $files = array())
+    {
+        if ($dh = opendir($dir))
         {
-            while (($res = readdir($dh)) !== false) 
+            while (($res = readdir($dh)) !== false)
             {
                 if(is_dir($dir . $res . '/') && $res != '.' && $res != '..') array_merge($files, $this->_getChangeLogs($dir . $res . '/', $files));
-                else 
+                else
                 {
-                    if (strpos($res, '.changes') !== false && $res[0] != '_') $files[] = $dir . $res; 
+                    if (strpos($res, '.changes') !== false && $res[0] != '_') $files[] = $dir . $res;
                 }
-            } 
+            }
             closedir($dh);
         }
-        return $files; 
-    } 
+        return $files;
+    }
 
     function _parseChange($line)
     {
         $record = Array();
         $parts = explode(DOKU_TAB, $line);
-        if ($parts && $parts[4] != "") 
+        if ($parts && $parts[4] != "")
         {
             $record["timestamp"] = $parts[0];
             $record["type"] = $parts[2];

--- a/gchart/gChart.php
+++ b/gchart/gChart.php
@@ -20,7 +20,7 @@ class gChart
      * @var string
      * @usedby getUrl()
      */
-    private $baseUrl = "chart.apis.google.com/chart?";
+    private $baseUrl = "chart.googleapis.com/chart?";
 
     /**
      * @brief Data set values.
@@ -257,14 +257,14 @@ class gChart
      * @brief Specifies the style of an axis.
      *
      * @param $axisIndex Integer This is a zero-based index into the axis array specified by setVisibleAxes
-     * @param $axisStyle String You can specify the font size, color, and alignment for axis labels, both custom labels and 
-     *                   default label values. All labels on the same axis have the same format. If you have multiple 
-     *                   copies of an axis, you can format each one differently. You can also specify the format of a 
+     * @param $axisStyle String You can specify the font size, color, and alignment for axis labels, both custom labels and
+     *                   default label values. All labels on the same axis have the same format. If you have multiple
+     *                   copies of an axis, you can format each one differently. You can also specify the format of a
      *                   label string, for example to show currency symbols or trailing zeroes.
-     *                   By default, the top and bottom axes do not show tick marks by the values, while the left and 
+     *                   By default, the top and bottom axes do not show tick marks by the values, while the left and
      *                   right axes do show them.
      *
-     *                   Refer to official documentation at: 
+     *                   Refer to official documentation at:
      *                   http://code.google.com/apis/chart/image/docs/gallery/bar_charts.html#axis_labels
      */
     public function addAxisStyle($axisIndex, $axisStyle)
@@ -275,18 +275,18 @@ class gChart
      * @brief Specifies the style of an axis.
      *
      * @param $axisIndex Integer This is a zero-based index into the axis array specified by setVisibleAxes
-     * @param $axisTickLength Integer You can specify long tick marks for specific axes. Typically this is 
-     *                        used to extend a tick mark across the length of a chart. Use the addAxisStyle() 
+     * @param $axisTickLength Integer You can specify long tick marks for specific axes. Typically this is
+     *                        used to extend a tick mark across the length of a chart. Use the addAxisStyle()
      *                        method to change the tick mark color.
      *
-     *                        Refer to official documentation at: 
+     *                        Refer to official documentation at:
      *                        http://code.google.com/apis/chart/image/docs/gallery/bar_charts.html#axis_labels
      */
     public function addAxisTickMarkStyle($axisIndex, $axisTickLength)
     {
         $this->setProperty('chxtc', $axisIndex.','.$this->encodeData($axisTickLength, '|'), true);
     }
-     /* 
+     /*
      * Extended Text.
      *
      * This specifies integer values from 0-4095, inclusive, encoded by two alphanumeric characters.
@@ -708,7 +708,7 @@ class gChart
      */
     public function getUrl()
     {
-        $fullUrl = "http://";
+        $fullUrl = "https://";
         if(isset($this->serverNum))
             $fullUrl .= $this->getServerNumber().".";
         $fullUrl .= $this->baseUrl;
@@ -747,7 +747,7 @@ class gChart
 		header('Content-type: image/png');
 		if ($post) {
 			$this->setDataSetString();
-			$url = 'http://chart.apis.google.com/chart?chid=' . md5(uniqid(rand(), true));
+			$url = 'https://' . $this->baseUrl . 'chid=' . md5(uniqid(rand(), true));
 			$context = stream_context_create(
 				array('http' => array(
 					'method' => 'POST',

--- a/syntax.php
+++ b/syntax.php
@@ -18,47 +18,47 @@ require_once DOKU_PLUGIN.'syntax.php';
 require_once DOKU_PLUGIN.'authorstats/helpers.php';
 require_once DOKU_PLUGIN.'authorstats/gchart/gChartInit.php';
 
-class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin 
+class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
 {
-    public function getType() 
+    public function getType()
     {
         return 'substition';
     }
 
-    public function getPType() 
+    public function getPType()
     {
         return 'stack';
-    } 
+    }
 
-    public function getSort() 
+    public function getSort()
     {
         return 371;
-    } 
+    }
 
-    public function connectTo($mode) 
+    public function connectTo($mode)
     {
         $this->Lexer->addSpecialPattern('<AUTHORSTATS>',$mode,'plugin_authorstats');
         $this->Lexer->addSpecialPattern('<AUTHORSTATS [0-9]+>',$mode,'plugin_authorstats');
         $this->Lexer->addSpecialPattern('<AUTHORSTATS YEARGRAPH>',$mode,'plugin_authorstats');
     }
 
-    public function handle($match, $state, $pos, &$handler)
+    public function handle($match, $state, $pos, $handler)
     {
         return array($match);
     }
 
-    public function render($mode, &$renderer, $data) 
+    public function render($mode, $renderer, $data)
     {
 
-        if ($mode == "metadata") 
+        if ($mode == "metadata")
         {
             $renderer->meta['authorstats-enabled'] = 1;
             return true;
         }
 
-        if($mode == 'xhtml') 
+        if($mode == 'xhtml')
         {
-            if (preg_match("/<AUTHORSTATS (?P<months>[0-9]+)>/", $data[0], $matches)) 
+            if (preg_match("/<AUTHORSTATS (?P<months>[0-9]+)>/", $data[0], $matches))
             {
                 $renderer->doc .= $this->_getMonthlyStatsTable(intval($matches[1]));
             }
@@ -66,7 +66,7 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
             {
                 $renderer->doc .= $this->getYearGraph();
             }
-            else 
+            else
             {
                 $renderer->doc .= $this->_getStatsTable();
             }
@@ -74,18 +74,18 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
     }
 
     // Returns the number of author's Contrib for a number of months
-    function _getLastMonthsContrib($author, $months) 
+    function _getLastMonthsContrib($author, $months)
     {
         $m = Array();
         $sum = 0;
         // Get an array of months in the format used eg. 201208, 201209, 201210
-        for ($i=$months-1; $i>=0; $i--) 
+        for ($i=$months-1; $i>=0; $i--)
             array_push($m, date("Ym", strtotime("-".$i." Months")));
-        
+
         // Sum the Contrib
-        foreach ($m as $month) 
+        foreach ($m as $month)
         {
-            if (array_key_exists($month, $author["pm"])) 
+            if (array_key_exists($month, $author["pm"]))
             {
                 $sum += intval($author["pm"][$month]);
             }
@@ -93,9 +93,9 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
         return $sum;
     }
 
-    function _sortByContrib($a, $b) 
+    function _sortByContrib($a, $b)
     {
-        return $this->_getTotalContrib($a) <= $this->_getTotalContrib(b) ? -1 : 1 ;
+        return $this->_getTotalContrib($a) <= $this->_getTotalContrib($b) ? 1 : -1 ;
     }
 
     function _getTotalContrib($a)
@@ -103,17 +103,17 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
         return (intval($a["C"]) + intval($a["E"]) + intval($a["e"]) + intval($a["D"]) + intval($a["R"]));
     }
 
-    function _sortByLastMonthsContrib($a, $b) 
+    function _sortByLastMonthsContrib($a, $b)
     {
         return $a['lmc'] >= $b['lmc'] ? -1 : 1;
-    } 
+    }
 
     function _getMonthlyContrib($authors, $yearmonth)
     {
         $sum = 0;
         foreach ($authors as $author)
         {
-            if (array_key_exists($yearmonth, $author["pm"])) 
+            if (array_key_exists($yearmonth, $author["pm"]))
             {
                 $sum += intval($author["pm"][$yearmonth]);
             }
@@ -131,7 +131,7 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
         $months = Array("January", "February", "March", "April","May","June","July","August","September","October", "November", "December");
         for ($i=0; $i < 12; $i++)
         {
-            array_push($totalpm, $this->_getMonthlyContrib($authors, date("Y").sprintf("%02s", $i))); 
+            array_push($totalpm, $this->_getMonthlyContrib($authors, date("Y").sprintf("%02s", $i)));
         }
         $lineChart = new gchart\gLineChart(800,300);
         $lineChart->addDataSet($totalpm);
@@ -150,48 +150,53 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
         // Append the parameters for the Axes Titles
         return $output."<img src=\"".$lineChart->getUrl()."\">";
     }
-    
+
     // Returns the HTML table with the authors and their stats
-    function _getStatsTable() 
-    {   
+    function _getStatsTable()
+    {
         $output = " <h3>General Statistics</h3><table class=\"authorstats-table\"><tr><th>Name</th><th>Creates</th><th>Edits</th><th>Minor edits</th><th>Deletes</th><th>Reverts</th><th>Contrib</th></tr>";
         $authors = authorstatsReadJSON();
+{"authors":{"laurent":{"C":60,"E":230,"e":78,"D":17,"R":5,"pm":{"201601":368,"201512":20,"201602":1}},"elsalu":{"C":1,"E":0,"e":0,"D":0,"R":0,"pm":[]}},"lastchange":1454489437}
+
         $authors = $authors["authors"];
         if (!$authors) return "There are no stats to output!";
         uasort($authors, array($this, '_sortByContrib'));
-        foreach ($authors as $name => $author) 
+        foreach ($authors as $name => $author)
         {
-            $output .= "<tr><th>" . 
-            $name . "</th><td>" . 
-            $author['C'] . "</td><td>" . 
-            $author['E'] .  "</td><td>" . 
-            $author['e'] . "</td><td>" . 
-            $author['D'] . "</td><td>" . 
-            $author['R'] . "</td><td>" . 
+            $output .= "<tr><th>" .
+            $name . "</th><td>" .
+            $author['C'] . "</td><td>" .
+            $author['E'] .  "</td><td>" .
+            $author['e'] . "</td><td>" .
+            $author['D'] . "</td><td>" .
+            $author['R'] . "</td><td>" .
             strval($this->_getTotalContrib($author))."</td></tr>";
         }
         $output .= "</table>";
         return $output;
     }
 
-    // Returns the HTML table with the authors and their Contrib for the 
+    // Returns the HTML table with the authors and their Contrib for the
     // last <$months> months
-    function _getMonthlyStatsTable($months) 
-    {   
+    function _getMonthlyStatsTable($months)
+    {
         $output = "<h3>Contribution in the last ".$months." months</h3><table class=\"authorstats-table\"><tr><th>Name</th><th>Contrib</th></tr>";
         $authors = authorstatsReadJSON();
         $authors = $authors["authors"];
         if (!$authors) return "There are no stats to output!";
-        foreach($authors as $name=>$author) 
+        foreach($authors as $name=>$author)
         {
             $authors[$name]['lmc'] = $this->_getLastMonthsContrib($author, $months);
-        } 
+        }
         uasort($authors, array($this, '_sortByLastMonthsContrib'));
-        foreach ($authors as $name=>$author) 
+        foreach ($authors as $name=>$author)
         {
-            $output .= "<tr><th>" . 
-            $name . "</th><td>" . 
-            strval($authors[$name]['lmc']) . "</td></tr>";
+			if ($authors[$name]['lmc'] > 0 )
+			{
+				$output .= "<tr><th>" .
+				$name . "</th><td>" .
+				strval($authors[$name]['lmc']) . "</td></tr>";
+			}
         }
         $output .= "</table>";
         return $output;

--- a/syntax.php
+++ b/syntax.php
@@ -156,8 +156,6 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
     {
         $output = " <h3>General Statistics</h3><table class=\"authorstats-table\"><tr><th>Name</th><th>Creates</th><th>Edits</th><th>Minor edits</th><th>Deletes</th><th>Reverts</th><th>Contrib</th></tr>";
         $authors = authorstatsReadJSON();
-{"authors":{"laurent":{"C":60,"E":230,"e":78,"D":17,"R":5,"pm":{"201601":368,"201512":20,"201602":1}},"elsalu":{"C":1,"E":0,"e":0,"D":0,"R":0,"pm":[]}},"lastchange":1454489437}
-
         $authors = $authors["authors"];
         if (!$authors) return "There are no stats to output!";
         uasort($authors, array($this, '_sortByContrib'));


### PR DESCRIPTION
Merge of
- Pull request : https://github.com/ConX/dokuwiki-plugin-authorstats/pull/30 - Adjust method signatures to match parent #30
Suppression des &$ (2 others variables found not in #30)

- Pull request : https://github.com/ConX/dokuwiki-plugin-authorstats/pull/24 - Small bug in function _sortByContrib and small change in monthly stats #24
Only a small bug fix "$b" in place of "b" and "1 : -1" in place of "-1 : 1" an little enhancement in monthly stats
this bug may be the one who causes "PHP Warning:  Illegal string offset 'C'" -> https://github.com/ConX/dokuwiki-plugin-authorstats/issues/28

My editor has also removed all extra-spaces...