### PR TITLE
action.php, helpers.php, & syntax.php updates for the year graph

### DIFF
--- a/action.php
+++ b/action.php
@@ -88,7 +88,9 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
         global $conf;
         $dir = $conf['metadir'] . '/';
 
-	$conf_mtime = @filemtime(DOKU_CONF."local.php");
+        authorstatsCreateDirIfMissing("data");
+
+        $conf_mtime = @filemtime(DOKU_CONF."local.php");
 
         // Return the files in the directory /data/meta
         $files = $this->_getChangeLogs($dir);
@@ -102,7 +104,7 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
 	// Delete JSON files and update everything if config file has changed
 	if ($lastchange < $conf_mtime) {
 		$lastchange = (-1*PHP_INT_MAX)-1;
-		array_map("unlink", glob(DOKU_PLUGIN."authorstats/*.json"));
+		array_map("unlink", glob(DOKU_PLUGIN."authorstats/data/*.json"));
 		$sd = Array();
 	}
         $newlast = $lastchange; 
@@ -165,7 +167,7 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
 
         if (isset($enabled)) 
         {
-            if (@filemtime($cache->cache) < @filemtime(DOKU_PLUGIN."authorstats/authorstats.json")) 
+            if (@filemtime($cache->cache) < @filemtime(DOKU_PLUGIN."authorstats/data/authorstats.json")) 
             {
                 $event->preventDefault();
                 $event->stopPropagation();

--- a/helpers.php
+++ b/helpers.php
@@ -11,7 +11,7 @@
 function authorstatsReadJSON() 
 {
     $json = new JSON(JSON_LOOSE_TYPE);
-    $file = @file_get_contents(DOKU_PLUGIN."authorstats/authorstats.json");
+    $file = @file_get_contents(DOKU_PLUGIN."authorstats/data/authorstats.json");
     if(!$file) return Array();
     return $json->decode($file);
 }
@@ -19,16 +19,17 @@ function authorstatsReadJSON()
 // Save the statistics into the JSON file
 function authorstatsSaveJSON($authors) 
 {
+    authorstatsCreateDirIfMissing("data");
     $json = new JSON();
     $json = $json->encode($authors);
-    file_put_contents(DOKU_PLUGIN."authorstats/authorstats.json", $json); 
+    file_put_contents(DOKU_PLUGIN."authorstats/data/authorstats.json", $json); 
 }
 
 // Read the saved statistics for user from the JSON file
 function authorstatsReadUserJSON($loginname)
 {
     $json = new JSON(JSON_LOOSE_TYPE);
-    $file = @file_get_contents(DOKU_PLUGIN."authorstats/".$loginname.".json");
+    $file = @file_get_contents(DOKU_PLUGIN."authorstats/data/".$loginname.".json");
     if(!$file) return Array();
     return $json->decode($file);
 }
@@ -36,9 +37,24 @@ function authorstatsReadUserJSON($loginname)
 // Save the statistics of user into the JSON file
 function authorstatsSaveUserJSON($loginname, $pages)
 {
+    authorstatsCreateDirIfMissing("data");
     $json = new JSON();
     $json = $json->encode($pages);
-    file_put_contents(DOKU_PLUGIN."authorstats/".$loginname.".json", $json);
+    file_put_contents(DOKU_PLUGIN."authorstats/data/".$loginname.".json", $json);
+}
+
+// Creat directory if missing
+function authorstatsCreateDirIfMissing($folder)
+{
+    $path = DOKU_PLUGIN."authorstats/$folder";
+    if (!file_exists($path))
+    {
+        mkdir($path, 0755);
+    }
+    else if (!is_dir($path))
+    {
+        // log or print an error
+    }
 }
 
 ?>


### PR DESCRIPTION
  - Moved the json files to a sub directory called data in the lib/plugins/authorstats folder.
    Longer term these should be moved to a better directory, but now it is at least not next
    to the php code.
    Old location of *.json:  lib/plugins/authorstats/
    New location of *.json:  lib/plugins/authorstats/data/
  - Call the function to create the data directory if it's missing.

helpers.php
  - Updated the json files path to use the new data directory.
  - Created a new function that will check if the data directory exists and if it's not then
    it will create it.
  - Called the new authorstatsCreateDirIfMissing() function to create the data dir for the
    json files.

syntax.php
  - Added a new Lexer for "<AUTHORSTATS YEARGRAPH>" type.  Now it will support a # and sort type.
    The new allowed format:  <AUTHORSTATS YEARGRAPH\s+\d*\s*\w*>
  - Updated the regex to support "<AUTHORSTATS YEARGRAPH [# of years] [asc|desc|reverse]>"
    "/<AUTHORSTATS YEARGRAPH\s*(?P<years>[0-9]+)*\s*(?P<sort>(:?asc|ascending|desc|descending|rev|reverse)*)>/"
  - Updated the getYearGraph() to accept the matches list from the preg_match() and now it will build
    a 1 year to date (last 12 prior months, plus the current month... 13 total) graph.  If the preg_match
    returns a year number or sort value, then it will add that many more years to the chart or change the sort
    order.
  - Made the chart.googleapis url a multiline to make it easier to read and to add comments to document
    what each value does.