### PR TITLE
Fix userlink()

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,5 +1,5 @@
 <?php
 $lang["show-realname"] = "Show the real names instead of usernames";
 $lang["enable-pagelist"] = "Enable showing a page list for each user statistic";
-$lang["show-profile-links"] = "Enable making the name link to the user's profile page";
+$lang["show-profile-links"] = "Use DokuWiki's format for user name eventually with link to the user's profile page. This format is set in 'showuseras' configuration setting.";
 $lang["show-deleted-users"] = "Show deleted users";

--- a/syntax.php
+++ b/syntax.php
@@ -248,6 +248,7 @@ class syntax_plugin_authorstats extends DokuWiki_Syntax_Plugin
         if ($user !== false and $this->getConf("show-realname")) {
             $dname = $user["name"];
         } else if ($this->getConf("show-profile-links")) {
+            $dname = userlink($name);
         } else if ($user !== false) {
             $dname = $name;
         } else {


### PR DESCRIPTION
Now now rows are shown, if this option is activated (and real name was disable).

NB: 'show-profile-links' is only used when 'show-realname' is disabled. I guess that for most users this is not obvious.
I think this can be solved nicely, by replacing these two on-off options by a combined dropdown. 
