### PR TITLE
Update action.php for PHP Warning

### DIFF
--- a/action.php
+++ b/action.php
@@ -189,6 +189,9 @@ class action_plugin_authorstats extends DokuWiki_Action_Plugin
         foreach ($file_contents as $line) {
             $r = $this->_parseChange($line);
 
+            if (!isset($r["author"]))
+                continue;
+
             if ($r["author"] == "")
                 continue;
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   authorstats
 author George Chatzisofroniou, Constantinos Xanthopoulos
 email  sophron@latthi.com, conx@xanthopoulos.info
-date   2022-3-12
+date   2024-06-11
 name   authorstats plugin
 desc   Plugin that outputs statistics about the wiki's authors.
 url    http://www.dokuwiki.org/plugin:authorstats


### PR DESCRIPTION
```
PHP Warning:  Undefined array key "author" in /var/www/html/doku/lib/plugins/authorstats/action.php on line 192, referer: http://x.x.x.x/doku/doku.php
```